### PR TITLE
Link to JS files with full path

### DIFF
--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -3,8 +3,8 @@
 <head>
 <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
 <title>WBS question types - Web-Based Straw-poll and Balloting System</title>
-<script type='text/javascript' src='/2008/site/js/jquery.js'></script>
-<script type='text/javascript' src='/2002/09/wbs/cumulative.js'></script>
+<script type='text/javascript' src=//w3.org/scripts/jquery/1.11/jquery.min.js'></script>
+<script type='text/javascript' src='//w3.org/2002/09/wbs/cumulative.js'></script>
 
 <!-- css test-->
   <link rel="stylesheet" type="text/css" href="http://www.w3.org/2008/site/css/minimum" media="handheld, all" />
@@ -13,8 +13,8 @@
   <link rel="stylesheet" type="text/css" href="../css/site-wbs-style.css" title="default" /> 
 <!--  -->
 
-<script src='/2002/09/wbs/autolinker-dom.js'></script>
-<script src='/2002/09/wbs/addLinks.js'></script>
+<script src='//w3.org/2002/09/wbs/autolinker-dom.js'></script>
+<script src='//w3.org/2002/09/wbs/addLinks.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
When you visit [`https://w3c.github.io/wbs-design/html/qtypes-site.html`](https://w3c.github.io/wbs-design/html/qtypes-site.html), 4 JS files aren't found; that's because they're linked with relative paths, but they don't exist under `w3c.github.io/wbs-design`. This PR adds the domain name.

While at it, I've also switched to using jQuery 1.11.x from our own JS repository (instead of the old copy, which hasn't been updated lately, and also was not minified).
