### PR TITLE
Fix layout

### DIFF
--- a/css/advanced.css
+++ b/css/advanced.css
@@ -1,0 +1,309 @@
+/*! 
+ * Source in advanced-src.css
+ */body{font-size:.82em;background:#fff url(http://www.w3.org/2008/site/images/page/page_bkg.jpg) repeat-x top left}
+body.w3c_member{background-image:url(http://www.w3.org/2008/site/images/page/page_bkg_member.jpg)}
+body.w3c_team{background-image:url(http://www.w3.org/2008/site/images/page/page_bkg_team.jpg)}
+#w3c_container{margin-right:2%;font-size:108%;line-height:1.41667}
+#w3c_mast{overflow:hidden}
+#w3c_mast p{font-style:italic;color:#424242;padding:20px 30px}
+#w3c_mast h1{float:left;padding:0;text-align:right;height:107px}
+#w3c_mast h1 a{display:block;float:left;background:url('http://www.w3.org/2008/site/images/logo-w3c-screen-lg') no-repeat top left;width:100%;height:107px;position:relative;z-index:1}
+#w3c_mast h1 a:hover{border:0}
+#w3c_mast h1 a img{display:none}
+.w3c_member #w3c_mast h1 a,.w3c_member #w3c_mast h1 a:hover,.w3c_team #w3c_mast h1 a,.w3c_team #w3c_mast h1 a:hover{border:0;text-decoration:none}
+.w3c_member #w3c_mast h1 a{background-image:url('http://www.w3.org/2008/site/images/logo-w3c-member-lg')}
+.w3c_team #w3c_mast h1 a{background-image:url('http://www.w3.org/2008/site/images/logo-w3c-team-lg')}
+.alt-logo{display:block;position:absolute;left:20px;z-index:0;background-color:#fff}
+#w3c_mast img{display:block;vertical-align:top}
+#w3c_nav{clear:none;overflow:hidden}
+#w3c_nav form#region_form{float:right;margin-right:20px;margin-top:8px}
+#w3c_nav form#region_form select{display:block;width:14.3em;max-width:14.3em;color:#333;border:1px solid #d1d1d1;float:left}
+#w3c_nav form#region_form select option{max-height:19px;overflow:hidden}
+#region_form input.button{display:inline}
+.main_nav{display:block;width:98%;margin-left:2.4%;float:left;padding:27px 0 0;text-shadow:0 1px 1px #FFF}
+.main_nav a,.main_nav a:link,.main_nav span{font-weight:normal}
+.main_nav a,.main_nav span{display:block}
+.main_nav a,.main_nav span{padding:10px 10px 12px;border-left:1px solid #ddd;border-right:1px solid #fff;color:#0c3d5f;border-bottom:0;text-decoration:none;text-transform:uppercase}
+.main_nav a:hover,.main_nav a:focus,.main_nav a.current{color:#333;background-color:#fafafa;border-bottom:0;-webkit-transition:all .3s ease-out;-moz-transition:all .3s ease-out;-o-transition:all .3s ease-out;transition:all .3s ease-out}
+.main_nav a,.main_nav a:link,.main_nav a:hover,.main_nav a:active,.main_nav a:visited{padding:10px 10px 12px}
+.main_nav li{float:left;text-align:center}
+.main_nav li.last-item a{border-right:0}
+.main_nav li.first-item a{border-left:0 none;text-align:left}
+.main_nav li.search-item{width:20%;float:right;margin-right:20px}
+.secondary_nav{margin-top:10px;margin-bottom:0;margin-left:3.2%;padding:5px 7px;float:left;font-size:88%;background:#e8e7e7;-webkit-box-shadow:0 1px 2px #fff;-moz-box-shadow:0 1px 2px #fff;-webkit-border-radius:5px;-moz-border-radius:5px;border-top:1px solid #bbb;border-left:1px solid #bbb}
+.secondary_nav li{display:inline;display:inline-block;padding-left:10px;float:left}
+.secondary_nav li.label{padding-left:5px;padding-right:3px}
+.secondary_nav li a:hover{text-decoration:none;border:0;color:#000}
+#search-form{border-bottom:1px solid #d1d1d1;border-left:1px solid #d1d1d1;border-right:1px solid #d1d1d1;border-top:1px solid #b6b6b6;background:url('http://www.w3.org/2008/site/images/search-bg.png') repeat-x top left;height:28px;width:100%;float:right;clear:both;position:relative;-webkit-border-radius:5px;-moz-border-radius:5px}
+#search-form input.text{border:0;color:#333;float:left;font-size:131%;margin-left:2px;margin-top:4px;width:70%}
+#search-form button{position:absolute;right:3px;top:6px;vertical-align:middle}
+#search-form button img.submit{float:right}
+#w3c_main{background:#eee;overflow:hidden}
+#w3c_logo_shadow{overflow:hidden;display:block}
+#w3c_logo_shadow img{width:100%;display:block}
+#w3c_main p,#w3c_main li{line-height:1.5}
+#w3c_main li.vevent .date,#w3c_main li.hentry .date{border-bottom:1px solid #e2e2e2;margin-bottom:18px;padding-bottom:4px}
+#w3c_main li.vevent p.summary a,#w3c_main li.vevent p.summary a:link,#w3c_main li.vevent p.summary a:visited,#w3c_main li.hentry p.entry-title a,#w3c_main li.hentry p.entry-title a:link,#w3c_main li.hentry p.entry-title a:visited{border:0}
+#w3c_main li.vevent p.summary a:hover,#w3c_main li.hentry p.entry-title a:hover{border-bottom:2px solid #005a9c}
+#w3c_main p.about{color:#23668f;margin-top:.7%;padding-top:0;font-size:91%}
+#w3c_main .bct{max-width:none;font-size:94%}
+#w3c_main .bct li.current{padding:0 0 9px}
+.w3c_public #w3c_main .bct li.current{background:#fff url('http://www.w3.org/2008/site/images/bct.png') no-repeat bottom center}
+.w3c_member #w3c_main .bct li.current{background:#fff url('http://www.w3.org/2008/site/images/bct-member.png') no-repeat bottom center}
+.w3c_team #w3c_main .bct li.current{background:#fff url('http://www.w3.org/2008/site/images/bct-team.png') no-repeat bottom center}
+.bct{padding:4px 20px 7px 0}
+.bct li .cr{padding:0 .83em}
+#w3c_crumbs br{display:inline}
+#w3c_crumbs_frame{background-color:#fff}
+.bct .skip{display:inline;background:#fff url('http://www.w3.org/2008/site/images/skip.png') no-repeat center;text-align:center;width:55px;float:right;position:relative;left:10px;bottom:3px}
+.bct .skip a{color:#333;font-size:85%}
+#w3c_footer{text-align:center;background:#fff url('http://www.w3.org/2008/site/images/footer-shadow.png') no-repeat top center;width:100%}
+#w3c_footer a:hover{text-decoration:underline}
+#w3c_footer-inner{padding:30px 0 20px;max-width:600px;margin:0 auto}
+#w3c_footer-inner ul{text-align:left}
+.w3c_footer-nav{float:left;margin-left:23px;margin-top:0}
+.w3c_footer-nav h3{text-align:left}
+.w3c_footer-nav ul{padding:10px 20px}
+.w3c_footer-nav a:hover img.social-icon{-moz-opacity:.6;-khtml-opacity:.6;opacity:.6}
+.copyright{clear:both;color:#333;font-size:94%;padding-top:30px}
+#w3c_footer a:link,#w3c_footer a:visited{border-bottom:0}
+.w3c_home .w3c_leftCol{display:block;float:left;padding-top:0}
+.w3c_leftCol{display:block;float:left;padding-top:0;clear:left}
+.w3c_leftCol h3 a:hover,h2.category a:hover{background:0;color:#2673ab;text-decoration:none}
+.w3c_mainCol{overflow:hidden;background-color:#fff;padding-left:3%;padding-bottom:3%;padding-top:1.1%}
+#w3c_mast h1,.w3c_leftCol{width:20%}
+#w3c_crumbs_frame,.line .size2on3{margin-right:1.3%}
+.w3c_member #w3c_acl{width:185px;padding-right:0;padding-left:0}
+.w3c_alt #w3c_acl,.w3c_member_alt #w3c_acl,.w3c_team #w3c_acl{margin:0;width:210px;text-align:right;padding:5px 0 0;float:left;color:#fff;font-weight:bold}
+.line,.lastUnit{overflow:hidden}
+.unit{float:left}
+.size1on2{width:50%}
+.size1on3{width:33.33333%}
+.size2on3{width:66.66666%}
+.size1on4{width:25%}
+.size3on4{width:75%}
+.size1on5{width:18%}
+.lastUnit{float:none;width:auto}
+.w3c_home .lastUnit h2.category{margin-bottom:15px}
+.intro{line-height:1.8em}
+#w3c_content_body .intro p,#w3c_content_body p.intro{color:#333;font-size:94%}
+ul.w3c_toc{background-color:#f2f7fb;padding:5px 20px;border-top:1px solid #fff;font-size:94%}
+ul.w3c_toc li{display:inline}
+ul.w3c_toc li.toc_prefix{margin-right:10px;padding:2px 4px;background-color:#fff}
+ul.w3c_toc li .bullet{font-size:144%;color:#cbd9e4;vertical-align:middle;padding:0 10px}
+.w3c_events_talks .date .dtstart .year{color:#fff;font-size:88%;font-weight:bold;float:none;margin:0;vertical-align:top}
+.w3c_events_talks .info-wrap{clear:none}
+.w3c_events_talks .date .dd-mmm{color:#333;font-size:81%;display:block;font-weight:bold;line-height:11px;text-transform:uppercase}
+.w3c_events_talks .date .dtstart{padding-top:2px}
+.w3c_events_talks .date .date-separator{display:none}
+.w3c_events_talks .date.single .dd-mmm{padding:2px 9px}
+.w3c_image{border:1px #999 solid;padding:2px}
+h2,.h2{margin-top:0}
+h1,h2,h3,h4,h5,h6,ul,ol,dl,p,pre,blockquote{padding:20px 20px 0}
+code{color:#000}
+h1+p,h2+p,h3+p,h4+p,h5+p{padding-top:0}
+h1,#w3c_mast h1,.h1{font-size:136%;font-weight:normal;overflow:hidden}
+h2,.h2{font-size:167%;font-weight:normal}
+h3,.h3{font-size:131%;font-weight:normal}
+h4,.h4{font-size:131%;font-weight:normal}
+h5,.h5{font-size:100%;font-weight:normal}
+h6,.h6{font-size:85%;font-weight:normal}
+.category{font-size:108%;font-weight:normal;font-style:normal;text-transform:uppercase;color:#333}
+h3.category{background:#e7e6e6 url('http://www.w3.org/2008/site/images/category-bg-fold.png') no-repeat bottom right;text-shadow:1px 1px 0 #fff;color:#347cb0;padding:0 6px 0 0;width:100%;position:relative;margin-top:13px}
+h2.category,.h2.category{background:#fcfbfb url('http://www.w3.org/2008/site/images/category-bg-right.png') repeat-x bottom right;text-shadow:1px 1px 0 #fff;color:#347cb0;padding:5px 11px 15px 10px;margin:20px 0 3px 10px;font-weight:bold}
+#w3c_home_member_testimonials h3{padding:0 20px}
+#w3c_home_sponsors p,#w3c_home_sponsors h3{text-align:center}
+h3.category .ribbon{background:#e7e6e6 url('http://www.w3.org/2008/site/images/category-bg.png') repeat-x bottom right;display:block;padding:8px 5px 13px 20px}
+h3.category a,h2.category a,.h2.category a{color:#17445f;font-weight:bold;border:0}
+h1.title{padding:10px 20px;font-size:200%;border-bottom:1px solid #c6d4e0;text-shadow:1px 1px 0 #fff}
+h1.title img{float:right;margin-top:-2px;display:inline}
+.media{width:auto}
+.headline h2,.headline h3,.headline h4{padding:5px 20px}
+ol.show_items li,.entry ol li,ul.show_items li,.entry ul li{margin-left:40px}
+.theme{padding-top:10px}
+.theme ul{display:none}
+.theme li.subhead ul{display:block}
+.theme li{border-bottom:1px solid #ddd}
+.theme li.subhead{border-bottom:0;padding:5px 0 5px 5px}
+.theme a{display:block;overflow:hidden;font-weight:normal;padding:5px 0 5px 5px}
+.theme a.current,.theme li.current a{background-color:#fff;border-bottom:0}
+.theme .icon{background:url(http://www.w3.org/2008/site/images/theme-all.png) no-repeat left top;height:22px;width:22px;display:block;float:left;margin-right:10px;-moz-border-radius:5px}
+.theme .devices .icon{background-position:-22px 0}
+.theme .arch .icon{background-position:-44px 0}
+.theme .design .icon{background-position:-66px 0}
+.theme .semantics .icon{background-position:-88px 0}
+.theme .services .icon{background-position:-110px 0}
+.theme .xml .icon{background-position:-132px 0}
+.theme .allspecs .icon{background-image:none}
+.theme_ext{padding:0}
+.theme_ext li.theme_ext_item{position:relative;padding-left:64px}
+.theme_ext li.theme_ext_item ul{font-size:85%;padding-left:20px}
+.theme_ext .icon{background:#ffc0cb url(http://www.w3.org/2008/site/images/icon_sprite.png) no-repeat 0 0;height:44px;width:44px;display:block;position:absolute;top:28px;left:20px}
+.theme_ext .about_donations .icon{background-position:-1144px 0}
+.theme_ext .about_facts .icon{background-position:-1100px 0}
+.theme_ext .about_jobs .icon{background-position:-1056px 0}
+.theme_ext .about_locations .icon{background-position:-1012px 0}
+.theme_ext .about_mission .icon{background-position:-968px 0}
+.theme_ext .about_press .icon{background-position:-924px 0}
+.theme_ext .comingsoon .icon{background-position:-880px 0}
+.theme_ext .membership_policies .icon{background-position:-660px 0}
+.theme_ext .membership_admin .icon{background-position:-704px 0}
+.theme_ext .membership_join .icon{background-position:-748px 0}
+.theme_ext .membership_fees .icon{background-position:-792px 0}
+.theme_ext .membership_benefits .icon{background-position:-836px 0}
+.theme_ext .participate_calendar .icon{background-position:-616px 0}
+.theme_ext .participate_groups .icon{background-position:-572px 0}
+.theme_ext .participate_implementation .icon{background-position:-528px 0}
+.theme_ext .participate_liaisons .icon{background-position:-484px 0}
+.theme_ext .participate_news .icon{background-position:-440px 0}
+.theme_ext .participate_promotion .icon{background-position:-396px 0}
+.theme_ext .participate_rss .icon{background-position:-352px 0}
+.theme_ext .participate_specifications .icon{background-position:-308px 0}
+.theme_ext .standards_agents .icon{background-position:-264px 0}
+.theme_ext .standards_webofdevices .icon{background-position:-220px 0}
+.theme_ext .standards_webarch .icon{background-position:-176px 0}
+.theme_ext .standards_webdesign .icon{background-position:-132px 0}
+.theme_ext .standards_semanticweb .icon{background-position:-88px 0}
+.theme_ext .standards_webofservices .icon{background-position:-44px 0}
+.theme_ext .standards_xml .icon{background-position:0 0}
+ul.theme.right-list{padding-top:5px}
+.theme.right-list li{border-bottom:1px solid #eee}
+.theme.right-list li a:hover{background-color:#eee}
+.w3c_home #w3c_most-recently{margin-top:0 !important;padding-top:0 !important}
+.date{margin-left:20px;font-size:88%}
+#w3c_most-recently .date{margin-left:10px}
+.vevent_list .location,.vevent_list .source,.vevent_list .eventtitle,.vevent_list .person,.hentry_list .entry-title,.hentry_list p.author{padding:0 20px}
+#workshopslist .date,#workshopslist .location,#workshopslist .host{padding:0;margin-left:20px;font-size:88%;color:#333}
+#workshopslist p.view_report{padding-top:5px}
+#workshopslist p.view_report a{background:url('http://www.w3.org/2008/site/images/icons/view-report.png') no-repeat top left;border:0;height:35px;padding:10px 0 0 45px;display:block}
+#workshopslist p.view_report a:hover{text-decoration:underline}
+#workshopslist .description p{padding:5px 20px 0}
+.main-content{position:relative}
+.w3c_events_talks{margin-top:20px;background-color:#eee}
+.w3c_events_talks .unit.size1on2,.w3c_events_talks .unit.size1on1{background:url('http://www.w3.org/2008/site/images/talks-bg-left.png') no-repeat top left}
+.w3c_events_talks .w3c_upcoming_events,.w3c_events_talks .w3c_upcoming_talks{background:url('http://www.w3.org/2008/site/images/talks-bg-right.png') no-repeat top right}
+.w3c_events_talks h2.category{margin:0 20px 20px;background:#f9f9f9 url('http://www.w3.org/2008/site/images/talks-bg.png') repeat-x bottom left}
+.w3c_events_talks .date{background:#aaa url('http://www.w3.org/2008/site/images/calendar-sprite.png') no-repeat top left;border:0;height:41px;width:42px;border:0;float:left;margin-right:10px;text-align:center}
+.w3c_events_talks ul.vevent_list li{float:left;width:100%}
+.w3c_events_talks ul.vevent_list .info-wrap{margin-left:75px}
+.w3c_events_talks ul.vevent_list .info-wrap p{padding:0 10px 0 0;font-size:88%}
+.w3c_events_talks ul.vevent_list .info-wrap p.summary{font-size:113%}
+.w3c_events_talks ul.vevent_list .info-wrap p.source{color:#9a1724}
+.w3c_events_talks .w3c_upcoming_events .date{background-position:0 0;margin-bottom:0}
+.w3c_events_talks .w3c_upcoming_talks .date{background-position:0 -49px;margin-bottom:0}
+#w3c_main .w3c_upcoming_events ul.vevent_list .location,#w3c_main .w3c_upcoming_talks ul.vevent_list .location,.w3c_events_talks ul.vevent_list .info-wrap .source{font-size:100%;font-style:italic;line-height:1.3}
+#w3c_main .w3c_upcoming_events ul.vevent_list .location{color:green}
+.w3c_events_talks ul.vevent_list .info-wrap .source{color:#9a1724}
+#region_form select{width:76%}
+.w3c_home #w3c_most-recently h3,#w3c_most-recently h3{margin-left:9px;padding-left:0}
+.w3c_home #w3c_most-recently h3 span a:hover{border:0}
+.w3c_home #w3c_most-recently h3 .expand_section:hover{cursor:pointer}
+.newsImage{overflow:hidden}
+a.imageLink.no-border img{border:0}
+a.imageLink img{float:left;margin-right:1em;display:block;text-decoration:none;border:1px solid #cddced;padding:2px}
+a.imageLink:hover img{border:1px solid #3a80b3}
+a.imageLink:hover.no-border img{opacity:.6;border:0}
+.expand_section a img{vertical-align:middle;padding-right:.4em}
+.w3c_javascript .expand_block .expand_description,.expand_block .expand_description{display:block;padding-bottom:20px;margin-bottom:10px;background:#EEE;border-top:1px solid #fff}
+p.more-content{font-size:81%;font-weight:bold}
+p.more-content a{border-bottom:0;color:#106f0d}
+p.more-content a:hover{border-bottom:2px solid #106f0d}
+.more.expand_section{margin:3px 0 5px 19px;-moz-box-shadow:1px 1px 0 #bbb;-webkit-box-shadow:1px 1px 0 #bbb;box-shadow:1px 1px 0 #bbb;background:#eee;padding:3px 4px;-moz-border-radius:3px;-webkit-border-radius:3px;border-radius:3px;font-size:80%;display:table}
+.more.expand_section a:link,.more.expand_section a:visited,.more.expand_section a:hover{text-decoration:none;border:0}
+.more.expand_section+div.expand_description{background:0}
+div.entry h3{clear:left}
+.w3c_javascript .expand_block h3{padding-top:0;padding-left:20px}
+.w3c_javascript .expand_block h4{padding-left:20px;color:#333}
+.w3c_javascript .expand_block.closed .expand_description,.w3c_javascript .closed .expand_description{display:none}
+.w3c_javascript .expand_block .headline,.expand_block .headline,.w3c_javascript .expand_block.closed .headline,.expand_block.closed .headline{background:#f1f7fb;border-bottom:1px solid #e2e2e2;padding:10px}
+#recentnews .expand_block .headline{padding:10px 10px 15px 0}
+#recentnews h2#recent{margin-bottom:10px}
+.w3c_javascript .expand_block.closed .headline,.expand_block.closed .headline{background:0}
+.w3c_javascript .expand_block.closed .headline:hover,.expand_block.closed .headline:hover{background-color:#f1f7fb}
+.hierarchy .expand_block .expand_description{margin-bottom:0}
+.w3c_screen .trviewcat h3,.trviewcat h3{font-size:108%}
+.w3c_screen .trviewcat h4,.trviewcat h4{font-size:100%}
+.menu.expand_block{padding-left:0}
+.w3c_javascript .expand_block.menu .expand_description{padding-left:20px}
+.more-news{font-size:131%}
+.more-news a{color:#036}
+.feedlink img{margin:0 0 0 6px;vertical-align:top}
+a.feedlink:link,a.feedlink:visited{border-bottom:0}
+#request_form,.request_form{width:50%}
+#request_form fieldset label,.request_form fieldset label{display:block;margin-top:10px}
+#request_form fieldset input,.request_form fieldset input,#request_form fieldset textarea,.request_form fieldset textarea{border:1px solid #777;padding:5px;color:#005a9c}
+#request_form fieldset input.error,.request_form fieldset input.error,#request_form fieldset textarea.error,.request_form fieldset textarea.error{border:2px solid #dc4747}
+#request_form fieldset input:focus,.request_form fieldset input:focus,#request_form fieldset textarea:focus,.request_form fieldset textarea:focus{outline:0;box-shadow:0 0 6px #99c0e0;-moz-box-shadow:0 0 7px #99c0e0;-webkit-box-shadow:0 0 7px #99c0e0;-webkit-transition:border .2s linear,-webkit-box-shadow .2s linear;-moz-transition:border .2s linear,-moz-box-shadow .2s linear;border-color:#628eaf}
+#request_form fieldset p,.request_form fieldset p{padding:0;font-size:90%;color:#666}
+.testimonial{padding:15px;margin:20px 0}
+.testimonial ul{padding:0;margin-left:50px}
+.w3c_message.error,.w3c_message.errors{background-color:#ffebe6;border:1px solid #d5a79c}
+.w3c_message.warning,.w3c_message.warnings{background-color:#fcfbe4;border:1px solid #d6d49e}
+.w3c_message.notice,.w3c_message.info,.w3c_message.messages{background-color:#f1fbeb;border:1px solid #aac28e}
+.w3c_message h3{display:block;height:40px;font-weight:600;letter-spacing:.02em;font-size:180%;text-shadow:0 1px 1px #fff;padding:3px 50px 0;background:url("http://www.w3.org/2008/site/images/icons/messages_sprite.png") no-repeat top left}
+.w3c_message.error,.w3c_message.errors h3{background-position:0 0;color:#cf3c3c}
+.w3c_message.warning,.w3c_message.warnings h3{background-position:0 -80px;color:#c6a712}
+.w3c_message.notice h3,.w3c_message.info h3,.w3c_message.messages h3{background-position:0 -40px;color:#65a020}
+#endorsed,#workshopsupcoming{background:0}
+#twitter_update_list li{background:#eee;-moz-border-radius:5px;border-radius:5px;-webkit-border-radius:5px;padding:5px 8px;width:80%;margin-bottom:1em;border-right:1px solid #d6d6d6;border-bottom:1px solid #d6d6d6}
+a.twit-time:link,a.twit-time:visited{font-size:85%;display:block;color:#878787;margin-top:7px;text-shadow:1px 1px 0 #fff;border-bottom:0}
+a.twit-time:hover{color:#a6a5a5}
+.rhs-logo{text-align:center;display:block;margin-top:20px}
+header,nav,section,aside,footer,article,hgroup{display:block}
+.team-photo{width:94%;-moz-box-shadow:0 2px 10px #bbb;-webkit-box-shadow:0 2px 10px #bbb;box-shadow:0 2px 10px #bbb;margin:25px 0 20px 7px;padding:10px;text-align:center}
+.team-photo img{width:99.8%;height:auto;margin-bottom:5px}
+.team-photo span{font-family:Georgia,Times,serif;font-style:italic}
+.team-photo img+span{text-transform:uppercase;color:#999;border-bottom:1px solid #eee;font-style:normal}
+.team-photo+.hierarchy .more.expand_section{margin:0}
+.w3c_javascript .expand_block .expand_description.people{background:#eee;margin:10px 0;font-size:100%;color:#036;text-shadow:1px 1px 0 #FFF;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px}
+.w3c_javascript .expand_block .expand_description.people p{padding:0 20px}
+.w3c_javascript .expand_block .expand_description.people p.people_row{color:#777;font-family:Georgia,Times,serif;font-style:italic;padding-top:12px}
+.plans{padding:0;overflow:hidden;margin:30px 20px 20px}
+.plans li p,.plans li h2{padding:0}
+.plans li{font-family:Georgia,Times,serif;padding:5px 5px 30px 5px;text-align:center;border-left:1px solid #eee;text-shadow:1px 1px 0 #fff;background:url("http://www.w3.org/2008/site/images/icons/sponsors_shape.png") no-repeat bottom center;min-height:350px}
+.plans li:first-child{border:0}
+.plans li:hover{background:#eee url("http://www.w3.org/2008/site/images/icons/sponsors_shape.png") no-repeat bottom center;color:#333;-webkit-transition:all .2s ease-out;-moz-transition:all .2s ease-out;-o-transition:all .2s ease-out;transition:all .2s ease-out}
+.plans li h2,.w3c_plans .intro h2{font-size:120%;color:#333;letter-spacing:.5px;line-height:1.2em;margin:0 0 10px;text-transform:uppercase}
+.w3c_plans .intro h2{font-size:140%}
+.w3c_plans .show_items,.w3c_plans p,.w3c_plans h3{padding:5px 0;clear:both}
+.w3c_plans h3{font-family:Georgia,Times,serif;font-size:120%}
+#w3c_main .plans li h2+p{font-style:italic;font-size:90%;letter-spacing:.4px;color:#333;line-height:1.15em;min-height:115px}
+#w3c_main .plans li a.call-to-action{font-family:"'Helvetica Neue'",Helvetica,Arial,Verdana,Geneva,sans-serif;font-size:80%;letter-spacing:.5px;-moz-border-radius:23px;-webkit-border-radius:23px;border-radius:23px;-moz-box-shadow:0 1px 2px rgba(0,0,0,0.5);-webkit-box-shadow:0 1px 2px rgba(0,0,0,0.5);box-shadow:0 1px 2px rgba(0,0,0,0.5);background-color:#bbb;background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#bbb));background-image:-moz-linear-gradient(0 100% 90deg,#bbb,#fff);border:0;color:#555;font-weight:bold;padding:6px 15px;text-shadow:0 1px 1px rgba(255,255,255,0.85)}
+#w3c_main .plans li a.call-to-action.external{background-color:#95bfd2;background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#95bfd2));background-image:-moz-linear-gradient(0 100% 90deg,#95bfd2,#fff)}
+#w3c_main .plans li a.call-to-action:hover{-moz-box-shadow:none;-webkit-box-shadow:none;box-shadow:none;color:#333}
+#w3c_main .plans li a.call-to-action+p{font-family:"'Helvetica Neue'",Helvetica,Arial,Verdana,Geneva,sans-serif;font-size:85%;letter-spacing:.4px;color:#333;line-height:1.15em;margin:20px 0 0;height:90px}
+.plans li span{background:url("http://www.w3.org/2008/site/images/icons/sponsors_sprite.png") no-repeat center;height:100px;display:block;margin:10px 0}
+.plans span.corporate{background-position:center -15px}
+.plans span.events{background-position:center -120px}
+.plans span.initiatives{background-position:center -235px}
+.plans span.validator{background-position:center -340px}
+.plans span.supporters{background-position:center -442px}
+@media screen and /*! space fix */(max-width:1000px){.plans li h2{font-size:100%}
+#w3c_main .plans li h2+p,#w3c_main .plans li a.call-to-action+p{font-size:80%}
+#w3c_main .plans li a.call-to-action{padding:3px 10px}
+.plans li span{background:url("http://www.w3.org/2008/site/images/icons/sponsors_sprite_small.png") no-repeat center}
+.plans li span{height:65px}
+.plans span.corporate{background-position:center 0}
+.plans span.events{background-position:center -65px}
+.plans span.initiatives{background-position:center -135px}
+.plans span.validator{background-position:center -200px}
+.plans span.supporters{background-position:center -260px}
+}
+.w3c_plans{padding:0 20px}
+.w3c_plans .intro.corporate,.w3c_plans .intro.supporterse,.w3c_plans .intro.events,.w3c_plans .intro.strategic,.w3c_plans .intro.developer{padding:0 100px 0 150px;margin:25px 0 10px 0;min-height:160px}
+.w3c_plans .intro.corporate{background:url("http://www.w3.org/2008/site/images/icons/sponsors_folder.png") no-repeat top left}
+.w3c_plans .intro.supporters{background:url("http://www.w3.org/2008/site/images/icons/sponsors_chair.png") no-repeat top left}
+.w3c_plans .intro.events{background:url("http://www.w3.org/2008/site/images/icons/sponsors_calendar.png") no-repeat top left}
+.w3c_plans .intro.strategic{background:url("http://www.w3.org/2008/site/images/icons/sponsors_globe.png") no-repeat top left}
+.w3c_plans .intro.developer{background:url("http://www.w3.org/2008/site/images/icons/sponsors_check.png") no-repeat top left}
+.w3c_plans .intro p,.w3c_plans .intro h2,.w3c_plans p{padding:0}
+#w3c_content_body .w3c_plans .intro p{color:#333;font-family:"'Helvetica Neue'",Helvetica,Arial,Verdana,Geneva,sans-serif;font-style:normal}
+.w3c_plans .intro h2,.w3c_plans h2[id]{font-family:Georgia,Times,serif;text-transform:uppercase;margin:0 0 7px 0}
+.w3c_plans h2[id]{background:url("http://www.w3.org/2008/site/images/underline.png") repeat-x 0 25px;float:left;margin:15px 0 0 0;padding:0 0 5px 0;font-size:130%;color:#333}
+#w3c_home_plans h2{font-family:Georgia,Times,serif;text-transform:uppercase;font-size:130%;background:url("http://www.w3.org/2008/site/images/underline.png") repeat-x 0 100%}
+#w3c_home_plans{text-align:center}
+#w3c_home_plans .sponsorLogo{margin-left:20px}
+.w3c_plans p,.w3c_plans ul{font-family:Georgia,Times,serif;padding-bottom:20px}
+.w3c_plans ul{font-style:italic}
+#w3c_main .w3c_plans h2[id]+ul li{line-height:1.35em}
+.shaded_box{background:none repeat scroll 0 0 #d8e7f3;border-bottom:1px solid #ccc;border-radius:7px 7px 7px 7px;padding:15px;text-shadow:1px 1px 0 #eee}

--- a/css/minimum.css
+++ b/css/minimum.css
@@ -1,0 +1,218 @@
+@charset "UTF-8";/*! 
+ * Source in minimum-src.css
+ */html{color:#000;background:#FFF}
+body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td,address{margin:0;padding:0}
+table{border-collapse:collapse;border-spacing:0;font-size:inherit}
+fieldset,img{border:0}
+address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal}
+li{list-style:none}
+caption,th{text-align:left}
+h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal}
+q:before,q:after{content:''}
+abbr,acronym{border:0;font-variant:normal}
+sup{vertical-align:text-top}
+sub{vertical-align:text-bottom}
+input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit}
+legend{color:#000}
+body{font-family:sans-serif}
+pre,code,kbd,samp,tt{font-family:monospace;line-height:100%}
+body{font-family:"'Helvetica Neue'",Helvetica,Arial,Verdana,Geneva,sans-serif;color:#333}
+em{font-style:italic}
+strong{font-weight:bold}
+#w3c_mast h1{background-color:#005a9c;width:auto;position:static;text-align:left;float:left;padding:0;margin:0;height:auto}
+.w3c_member #w3c_mast h1{background-color:#6d3792}
+.w3c_team #w3c_mast h1{background-color:#a34425}
+#w3c_nav{background-color:#eee;clear:both}
+#w3c_mast{overflow:visible}
+#w3c_mast img{display:inline}
+#w3c_mast h1 a{background:0;display:inherit;float:none;height:auto;position:static;width:auto}
+#w3c_mast h1 a img{padding:0;margin:0;float:left;display:block}
+.w3c_member #w3c_mast h1 a{background:url('http://www.w3.org/2008/site/images/logo_member_mobile') no-repeat top left}
+.w3c_team #w3c_mast h1 a{background:url('http://www.w3.org/2008/site/images/logo_team_mobile') no-repeat top left}
+#search-form .text{background:#fff url('http://www.w3.org/2008/site/images/google') no-repeat center left;min-width:2em}
+#search-form .text:focus{background:#fff}
+@media screen{.secondary_nav a{display:block;color:#000;text-decoration:none}
+.secondary_nav a:link,.secondary_nav a:visited{color:#888}
+.secondary_nav{padding:5px 20px 0 0;font-size:88%;margin-bottom:10px}
+.secondary_nav li{padding-left:5px;margin:0}
+.secondary_nav li{display:-moz-inline-stack;display:inline-block;vertical-align:top;float:left}
+.main_nav li{display:none}
+.main_nav li.search-item{display:list-item}
+.w3c_home .main_nav{display:block}
+.main_nav a{padding:0;padding-right:1em;display:inline}
+.main_nav{padding-top:0;padding-left:5px;float:none;clear:left}
+.main_nav li{display:inline;float:none;margin:0}
+#w3c_main{clear:both;background-image:none}
+#w3c_logo_shadow,#w3c_crumbs br{display:none}
+.bct{padding:5px}
+.bct li{display:inline}
+.bct li .cr{padding:0}
+.bct .skip{display:none}
+#w3c_footer{text-align:left}
+#w3c_footer-inner{padding:5px}
+.alt-logo{display:none}
+.bar{padding-left:.25em;padding-right:.25em}
+.w3c_footer-nav h3{font-weight:bold;font-size:119%;color:#17445f;text-transform:uppercase}
+.w3c_footer-nav{margin-top:20px}
+.w3c_leftCol{display:none}
+.w3c_home .w3c_leftCol{display:none}
+.w3c_member #w3c_footer-inner{background-image:none}
+.w3c_member #w3c_acl{text-transform:uppercase;letter-spacing:.2em;width:auto;text-align:right;padding:5px 10px 0 5px;float:left;font-size:81%}
+.w3c_member_only{margin-top:-60px}
+#w3c_crumbs{background:0}
+.w3c_member #w3c_crumbs{background:0}
+#w3c_footer{padding-left:0}
+.w3c_mainCol,#w3c_footer-inner,#w3c_crumbs_frame{border-left:0}
+#w3c_crumbs_frame{margin-left:0}
+.line{margin-bottom:10px}
+.w3c_javascript.w3c_handheld .line .size2on3{margin:0}
+.size1on1,.size1on2,.size1on3,.size2on3,.size1on4,.size3on4{float:none;width:auto}
+.lastUnit{float:none}
+.intro{font-size:100%;line-height:1.2em}
+.offscreen{position:absolute;left:-1000em}
+.tPadding0{padding-top:0 !important}
+.rPadding0{padding-right:0 !important}
+.bPadding0{padding-bottom:0 !important}
+.lPadding0{padding-left:0 !important}
+.padding{padding:20px !important}
+.tPadding{padding-top:20px !important}
+.rPadding{padding-right:20px !important}
+.bPadding{padding-bottom:20px !important}
+.lPadding{padding-left:20px !important}
+.lPaddingLg{padding-left:40px !important}
+.tPaddingLg{padding-top:40px !important}
+.rPaddingLg{padding-right:40px !important}
+.bPaddingLg{padding-bottom:40px !important}
+.tMargin0{margin-top:0 !important}
+.rMargin0{margin-right:0 !important}
+.bMargin0{margin-bottom:0 !important}
+.lMargin0{margin-left:0 !important}
+.tMargin{margin-top:20px !important}
+.rMargin{margin-right:20px !important}
+.bMargin{margin-bottom:20px !important}
+.lMargin{margin-left:20px !important}
+.tMarginLg{margin-top:40px !important}
+.rMarginLg{margin-right:40px !important}
+.bMarginLg{margin-bottom:40px !important}
+.lMarginLg{margin-left:40px !important}
+h2,.h2{margin-top:20px}
+h1,h2,h3,h4,h5,ul,ol,dl,p,pre,blockquote{padding:5px 5px 0}
+table h4,table p,table ul,table ol{padding:0}
+ul ul,ol ol{padding:0 20px}
+dt{padding:0 20px}
+dd{padding:0 20px 10px}
+.block{margin:20px}
+hr{border:5px solid #bcbcbc;border-width:0 0 5px;margin:20px 20px 0}
+h1,.h1{font-size:131%;font-weight:bold;font-style:normal;color:#025a9a}
+h2,.h2{font-size:125%;font-weight:bold;font-style:normal;color:#036}
+h3,.h3{font-size:113%;font-weight:normal;font-style:normal;color:#025a9a}
+h4,.h4{font-size:106%;font-weight:bold;font-style:normal;color:#036}
+h5,.h5{font-size:106%;font-weight:bold;font-style:normal;color:#930}
+.title{padding:0 5px;background:#dbe7f0;font-weight:normal;letter-spacing:-0.05em;text-transform:uppercase;color:#000}
+.w3c_member .title{background:#f8efff;border-bottom:1px solid #e2d1ef}
+.w3c_team .title{background:#ffeadf;border-bottom:1px solid #dfa999}
+h1.title{letter-spacing:.01em}
+h1.title img{display:none}
+.category a{color:#333;font-weight:normal}
+a{color:#036}
+a img{cursor:pointer}
+a:visited{color:#006ec6}
+a:link,a:visited,a:hover{text-decoration:none}
+a:active{outline:0 none;position:relative;top:1px}
+.logo a:active{top:0}
+.theme_ext h2.w3c_topic a:active{position:static}
+a:link,a:visited{border-bottom:1px solid #a8bfcf;padding-bottom:0}
+a.no-border:link,a.no-border:visited,a.no-border:hover{border:0}
+.menu a:link,.menu a:visited{color:#036;border-bottom:transparent 2px solid}
+.w3c_leftCol a:link,.w3c_leftCol a:visited,ul.theme li a:link,ul.theme li a:visited{border-bottom:0}
+.bct a:link,.bct a:visited{border-bottom:0;padding-bottom:0}
+h1 a:link,.h1 a:link,h2 a:link,.h2 a:link,h3 a:link,.h3 a:link,h4 a:link,.h4 a:link{font-weight:normal;border-bottom:transparent 2px solid}
+h5 a:link,.h5 a:link{color:#930;font-weight:normal;border-bottom:transparent 2px solid}
+.h1 a:visited,h1 a:visited,.h2 a:visited,h2 a:visited,.h3 a:visited,h3 a:visited,.h4 a:visited,h4 a:visited{font-weight:normal;color:#036;border-bottom:transparent 2px solid}
+.h5 a:visited,h5 a:visited{font-weight:normal;color:#930;border-bottom:transparent 2px solid}
+.w3c_toc a:link,.w3c_toc a:visited,.data a:link,.data a:visited{border-bottom:transparent 2px solid}
+.w3c_leftCol a:link:after,.w3c_leftCol a:visited:after,table a:link:after,table a:visited:after,.expand_section a:link:after,.expand_section a:visited:after{content:none}
+a:hover,.main_nav a:hover,.menu a:hover,h1 a:hover,.h1 a:hover,h2 a:hover,.h2 a:hover,h3 a:hover,.h3 a:hover,h4 a:hover,.h4 a:hover,h5 a:hover,.h5 a:hover,.w3c_toc a:hover,.data a:hover,.bct a:hover{border-bottom:#005a9c 2px solid}
+.w3c_leftCol a:hover,.w3c_leftCol li a:focus{background-color:#fafafa;-moz-transition-property:background-color;-webkit-transition-property:background-color;-o-transition-property:background-color;-moz-transition-duration:.3s;-webkit-transition-duration:.3s;-o-transition-duration:.3s}
+.w3c_javascript.w3c_handheld .headline,.w3c_javascript.w3c_handheld .headline h3.h4,.w3c_javascript.w3c_handheld #w3c_most-recently h3 a{border:0;margin:0;background-color:#f1f7fb;font-weight:bold}
+ol.show_items li,.entry ol li{list-style-type:decimal}
+ul.show_items li,.entry ul li{list-style-type:disc}
+ol.show_items li,.entry ol li,ul.show_items li,.entry ul li{margin-left:20px}
+.vevent_list,.hentry_list{padding:0}
+.vevent_list .location,.vevent_list .eventtitle,.vevent_list .person,.hentry_list .entry-title{text-align:left;padding:0 5px;margin-left:0}
+.vevent_list .summary{padding-bottom:0}
+.w3c_events_talks .vevent_list li{padding-bottom:30px}
+.theme_ext{padding:0}
+.theme_ext li.theme_ext_item{position:relative;padding-left:0;min-height:0}
+.theme_ext .icon{display:none}
+h4.w3c_status_title{padding-bottom:0}
+p.rec_support_data{font-size:75%;padding-bottom:5px;padding-top:0}
+p.rec_support_data a{display:inline}
+.date{margin:0 20px 0 5px;padding:2px 0 0}
+.w3c_events_talks .date{padding:0;float:left;text-align:right}
+.w3c_events_talks .info-wrap{clear:both}
+.w3c_events_talks .date .dtstart .year{float:right;margin-left:10px}
+.date .mm-dd,.date .dtend .year,.date .paren{display:none}
+.w3c_javascript.w3c_handheld .date{font-weight:bold}
+.w3c_events_talks .date .date-separator{display:inline}
+.entry .summary,.vevent .summary{padding-top:0}
+.data{padding:20px 0;position:relative;vertical-align:top;border-right:solid 1px transparent}
+.data table{width:100%;border-top:3px solid #bcbcbc}
+th,td{vertical-align:top}
+.data th,.data td{border-right:1px solid #FFF;border-bottom:1px solid #FFF;padding:5px 20px}
+.data .lastColumn{border-right:0}
+.data .lastRow td{border-bottom:0}
+.data tr.even{background-color:#f8f8f8}
+.data tr.odd{background-color:#e2e2e2}
+.data tbody tr:nth-child(even){background-color:#f8f8f8}
+.data tbody tr:nth-child(odd){background-color:#e2e2e2}
+.data th{color:#000;font-weight:bold}
+.spec{padding:20px}
+.spec th,.spec td{border:1px solid #aaa;border-width:1px 0;padding-left:0}
+.spec tbody tr:nth-child(even),.spec tbody tr:nth-child(odd){background-color:#fff}
+.data .table_datecol{width:12%}
+.data .table_labelcol{width:20%}
+.data .table_titlecol{width:60%}
+.w3c_spec_summary_table td{padding:3px 1em 0}
+.w3c_spec_summary_table td .expand_description{padding-bottom:1em}
+.w3c_spec_summary_table .table_datecol{width:5.5em}
+.w3c_more_recent_status{font-size:75%;margin-top:0;margin-bottom:5px;padding-top:0}
+.w3c_more_recent_status a{background-color:#ffea6f;color:#000}
+.tr_view_nav{margin-left:0}
+figure img{max-width:100%}
+input{font-size:inherit;font-family:inherit}
+.button{border:0;-moz-border-radius:3px;-moz-box-shadow:0 1px 3px rgba(0,0,0,0.5);-webkit-border-radius:3px;-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.5);border-bottom:1px solid rgba(0,0,0,0.25);background-color:#555;color:#FFF;cursor:pointer;font-size:81%;font-weight:bold;left:5px;padding:2px 5px;position:relative;text-shadow:0 -1px 1px rgba(0,0,0,0.25)}
+.button:hover{background-color:#3a80b3;color:#fff}
+.button:active{top:1px}
+textarea,select{max-width:100%}
+.w3c_javascript.w3c_handheld input.text{width:80%}
+.w3c_javascript.w3c_handheld input.submit{font-size:88%;padding:.2em .2em .2em .4em;position:relative;right:35px;top:5px}
+#search-form button{font-size:88%;padding:0;position:relative;right:45px;top:2px;border-style:none;background:0}
+#region_form select{width:80%;font-size:94%}
+.w3c_toggle_form{width:15em;border:1px #dbe7f0 solid;padding:5px}
+.w3c_javascript .expand_block h3{padding-left:5px}
+.w3c_javascript.w3c_handheld .expand_block h3{border-top:1px #e2e2e2 solid}
+.w3c_javascript .expand_block h4{padding-left:5px;font-weight:normal}
+.w3c_javascript .expand_block .expand_description{padding-bottom:5px;margin-bottom:20px;background:0;border:0;display:block}
+.w3c_javascript.w3c_handheld .expand_block .expand_section{background:0;padding-left:0}
+.hierarchy{list-style:none}
+li.top{clear:both;margin-left:1em}
+.menu{padding:0 20px}
+.menu.expand_block{padding-left:20px}
+.menu h2.h4{font-size:100%;color:#666;background:#fff;letter-spacing:1.1px;padding-left:0;border-bottom:1px solid #ddd}
+.menu.expand_block h2{padding-top:0;padding-left:20px;margin-top:20px;margin-left:0}
+.w3c_javascript.w3c_handheld .expand_block.menu .expand_description,.expand_block.menu .expand_description{margin-left:0;padding-left:0}
+.menu ul{padding-top:.2em;padding-left:0;padding-right:0}
+}
+#request_form fieldset p,.request_form fieldset p{padding:0;color:#666}
+#request_form fieldset textarea,.request_form fieldset textarea,.errors{width:85%}
+.errors h3{background-image:none;padding:0}
+.errors ul{margin-left:0}
+/*! 
+ * Many thanks to Sorin Stefan and Nicole Sullivan!
+ * (Refers to section A. Libraries) 
+ * Copyright (c) 2007, Yahoo! Inc. All rights reserved.
+ * Code licensed under the BSD License:
+ * http://developer.yahoo.net/yui/license.txt
+ * version: 2.2.1
+ */

--- a/css/site-wbs-style-complex.css
+++ b/css/site-wbs-style-complex.css
@@ -84,8 +84,3 @@ body {
 	padding:0;
 	}
 }
-
-
-form {
-  border-bottom:thin black solid;
-}

--- a/css/site-wbs-style.css
+++ b/css/site-wbs-style.css
@@ -13,11 +13,6 @@ blockquote.member {
   background-color:#DDD;
 }
 
-form div, p.comment {
-  margin-left:2em;
-}
-
-
 blockquote.debug {
 color:red; display: none;
 }
@@ -140,10 +135,6 @@ table.results td.meta {
   color:black;
 }
 
-h1 {
-  border-bottom:thick black solid;
-}
-
 h1 a:link, h1 a:visited {
   text-decoration:none;
 }
@@ -218,13 +209,7 @@ html {
 
 body {
    margin:0;
-   padding:1em;
-   background: #fff;
    color: #000;
-}
-
-html, body, h2, h3, h4, div, p, ul, li, input, legend {
-	font-family: "Trebuchet ms", "Gill sans", sans-serif;
 }
 
 /* ******************  header  *************** */

--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -7,9 +7,9 @@
 <script type='text/javascript' src='//w3.org/2002/09/wbs/cumulative.js'></script>
 
 <!-- css test-->
-  <link rel="stylesheet" type="text/css" href="//www.w3.org/2008/site/css/minimum" media="handheld, all" />
-  <style type="text/css" media="print, screen and (min-width: 481px)">@import url("//www.w3.org/2008/site/css/advanced.css");</style>
-  <link rel="stylesheet" type="text/css" href="//www.w3.org/2008/site/css/minimum.css" media="handheld, only screen and (max-device-width: 480px)" />
+  <link rel="stylesheet" type="text/css" href="../css/minimum.css" />
+  <link rel="stylesheet" type="text/css" href="../css/advanced.css" media="print, screen and (min-width: 481px)" />
+  <link rel="stylesheet" type="text/css" href="../css/minimum.css" media="handheld, only screen and (max-device-width: 480px)" />
   <link rel="stylesheet" type="text/css" href="../css/site-wbs-style.css" title="default" /> 
 <!--  -->
 


### PR DESCRIPTION
There are some differences between [`w3c.github.io/wbs-design/html/qtypes-site.html`](https://w3c.github.io/wbs-design/html/qtypes-site.html) and the w3.org pages with the 2008 design, eg [`w3.org/Consortium/siteindex.html`](http://www.w3.org/Consortium/siteindex.html).

Using that last page as a reference, this PR tries to polish a few problems with the current page: margins, borders and paddings, background images and fonts.

One problem was that the CSS files linked from `w3.org/2008/site/` were in turn importing a bunch of images with relative paths (eg, `url(../images/page/page_bkg.jpg)`), so those weren't being loaded. I've copied here the original `advanced.css` and `minimum.css`, **and modified all paths** to make them absolute, so that images are loaded when viewing here on `github.io` too.

I've also deleted a few rules in `css/site-wbs-style.css` and `css/site-wbs-style-complex.css` that I did not understand, and that were changing a few things, eg fonts.

@lcarcone, you may want to review these changes to make sure I'm not breaking intentional styles, eg some elements within the questionnaires etc.
