### PR TITLE
Limit width of elements

### DIFF
--- a/css/site-wbs-style.css
+++ b/css/site-wbs-style.css
@@ -38,6 +38,7 @@ div.question {
 }
 
 div.question .overlarge {
+  width: 100vw;
   overflow-x: auto;
 }
 

--- a/css/site-wbs-style.css
+++ b/css/site-wbs-style.css
@@ -37,6 +37,14 @@ div.question {
   margin-right: 10px;
 }
 
+div.question .overlarge {
+  overflow-x: auto;
+}
+
+.overlarge table {
+  table-layout: fixed;
+}
+
 div.question h2  {
   background:#b3cdf3;
   color: #111;

--- a/css/site-wbs-style.css
+++ b/css/site-wbs-style.css
@@ -24,7 +24,7 @@ color:red; display: none;
 }
 
 div.question, tr.even  {
-  background:#fafafa; 
+  background:#fafafa;
   color: black;
   margin-bottom:30px;
   margin-top:10px;
@@ -38,7 +38,7 @@ div.question {
 }
 
 div.question h2  {
-  background:#b3cdf3; 
+  background:#b3cdf3;
   color: #111;
   font-size:1.3em;
   padding:8px;
@@ -46,7 +46,7 @@ div.question h2  {
 }
 
 div.question ul {
-  background:#fff; 
+  background:#fff;
   color: black;
   border:1px solid #aaa;
   padding:5px;
@@ -129,8 +129,8 @@ div.question h3 {
 }
 
 div.question legend {
-  //display:inline; 
-  background:#b3cdf3; 
+  //display:inline;
+  background:#b3cdf3;
   color: #111;
   font-size:1.4em;
   padding-top: 8px;
@@ -198,14 +198,12 @@ h1 a:link, h1 a:visited {
   text-decoration:none;
 }
 
-
-/*
 textarea {
-  width:50em;
-  max-width:90%;
+  width: 100%;
+/*  max-width:90%;
   height:8em;
-  margin-left:2em;
-}*/
+  margin-left:2em; */
+}
 
 textarea.comment {
  height:6em;
@@ -234,7 +232,7 @@ table.eval th, table.eval td /* label */ {
 
 ul.edit dt {
   margin-left:0.6em;
-  
+
 }
 
 ul.edit label {
@@ -317,8 +315,8 @@ body {
 .maintainer {
   font-size: small;
   background-color: #f5f5f5;
-  margin: 30px 20px -10px 20px;   
-  padding: 5px 5px 5px 3px;   
+  margin: 30px 20px -10px 20px;
+  padding: 5px 5px 5px 3px;
   text-align: justify;
 }
 
@@ -327,7 +325,7 @@ body {
 
 .small, .archive, .disclaimer {
    font-size: small;
-   margin:0.5em 17em 2em 2em;   
+   margin:0.5em 17em 2em 2em;
 }
 
 hr { margin: 0 17em 0 2em;
@@ -353,11 +351,11 @@ a img { color: #fff; }         /* hide the border in Netscape 4 */
  	     table-layout:fixed;
  	     width:100%;
  	   }
- 	 
+
  	   table.results thead th {
  	     width:5em;
  	   }
- 	 
+
  	   table.results thead th.meta {
  	     width:20em;
  	   }
@@ -441,14 +439,14 @@ a.edit img {
   content:url("icons/info.png");
 }
 
-tr.odd  { 
-   background-color:#c2cdde; 
+tr.odd  {
+   background-color:#c2cdde;
    color: black
 }
 
 tr.odd th a:link, tr.odd th a:visited {
    color: #005a9c;
-   background-color:#c2cdde; 
+   background-color:#c2cdde;
 }
 
 tr.even th a:visited {
@@ -496,15 +494,15 @@ ul.multicompare li label {
   margin-top: .5em;
 }
 
-.commentblock { clear: left } 
+.commentblock { clear: left }
 
-div.ms_importance_satis table tr td, 
-div.ms_importance_satis table tr th 
+div.ms_importance_satis table tr td,
+div.ms_importance_satis table tr th
   {
   border-bottom: thin #005a9c solid;
   }
 
-div.ms_importance_satis table tr th 
+div.ms_importance_satis table tr th
   {
   text-align: left;
   }
@@ -541,7 +539,7 @@ form.login ul li { border-top:none;}
 ul.alternative a:link, ul.alternative a:visited { background-color: inherit;}
 
 input.irreversible {
-  background-color:#faa;	
+  background-color:#faa;
 }
 
 /* Add a clear, just in case the items in a .multi contain floating images */

--- a/css/site-wbs-style.css
+++ b/css/site-wbs-style.css
@@ -38,7 +38,6 @@ div.question {
 }
 
 div.question .overlarge {
-  width: 100vw;
   overflow-x: auto;
 }
 
@@ -55,23 +54,19 @@ div.question h2  {
 }
 
 div.question ul {
-  background:#fff;
   color: black;
-  border:1px solid #aaa;
   padding:5px;
-  width:75%;
 }
 
 div.question input {
   margin-right:5px;
 }
 
-div.question ul, div.question select , div.question table {
-  margin-left: 20px;
-}
-
-div.question table {
-  margin-top: 20px;
+div.question table,
+div.question table.tMargin {
+  width: 100%;
+  margin: 0 0 .5em 0 !important;
+  padding: 0;
   border-collapse: initial;
 }
 
@@ -90,28 +85,31 @@ div.question table.eval th a:visited {
    color: #cbf;
 }
 
-div.content, div.widget {
-  margin-left: 1em;
+div.content,
+div.widget {
+  margin: 0 2em .5em 2em;
 }
 
-div.content p {
+div.content p,
+div.widget p {
+  margin-bottom: .5em;
+  padding: 0;
   font-size:1.05em;
+  line-height: 100%;
 }
 
 input, textarea, select {
+  margin-bottom: .5em;
   font-size: 0.90em;
 }
 
 #w3c_content_body form ul {
   list-style:none;
-  margin-bottom:30px;
-  margin-top:10px;
+  margin: 0 0 .5em 0;
 }
 
 #w3c_content_body form ul li {
-  padding-top:4px;
-  padding-bottom:2px;
-  padding-left:3%;
+  padding: 0;
 }
 
 #w3c_content_body form ul li:first-child {
@@ -475,12 +473,14 @@ tr.odd:hover, tr.odd:focus {
 ul.compare li label {
   display:block;
   float:left;
-  width:50%;
 }
 
 ul.compare li {
   clear: left;
-  margin-bottom:.5em;
+}
+
+ul.compare li select {
+  margin-left: 2em;
 }
 
 ul.multicompare li .topic, ul.multicompare li label {
@@ -505,15 +505,10 @@ ul.multicompare li label {
 
 .commentblock { clear: left }
 
-div.ms_importance_satis table tr td,
-div.ms_importance_satis table tr th
-  {
-  border-bottom: thin #005a9c solid;
-  }
-
 div.ms_importance_satis table tr th
   {
   text-align: left;
+  overflow: hidden;
   }
 
 strong.ownanswer {
@@ -566,4 +561,33 @@ a.edit {
 a.edit:hover, a.edit:active, a.edit:focus {
   opacity: 1;
   border-bottom: none;
+}
+
+p.rationaleblock,
+p.commentblock {
+  margin-bottom: .5em;
+  padding: 0;
+}
+
+q {
+  font-style: italic;
+}
+
+.data tbody tr:nth-child(odd) {
+  background-color: #f5f5ff;
+}
+
+.data tbody tr:nth-child(even) {
+  background-color: #fffff5;
+}
+
+.data th,
+.data td {
+  border: none;
+  padding: .4em 1em;
+  overflow: hidden;
+}
+
+.data select {
+  margin: 0;
 }

--- a/html/index-site-select2.html
+++ b/html/index-site-select2.html
@@ -2,8 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1,
-shrink-to-fit=no" />
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 <title>WBS: Web-Based Straw-poll and balloting system - Web-Based Straw-poll and Balloting System</title>
 <!-- <link rel="stylesheet" type="text/css" href="../css/wbs-style.css" title="default" />-->
 <link rel="alternate" type="application/atom+xml" href="https://www.w3.org/2002/09/wbs/myQuestionnaires.atom"

--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -289,6 +289,7 @@ you think are acceptable (i.e.  you can
 live with it), where 1  is the most preferred, 2 the next best and so on... You also have a <q>don’t mind</q> and a <q>don’t want</q> option.</p>
 <input type='hidden' name='q11:format' value='1' /><input
   type='hidden' name='q11:dim' value='5' />
+<div class="overlarge">
 <table class="records_list data tMargin">
 <thead>
 <tr><th>Rank</th><th>Choice</th></tr>
@@ -319,7 +320,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 <td>choice 3</td>
 </tr>
 </tbody>
-</table>
+</table></div>
 <p class="rationaleblock"><label for='xq11:rationale'>Rationale</label>: <br />
 <textarea id ='xq11:rationale' name='q11:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq11:comment'>Comments:</label> <br />
@@ -334,6 +335,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 </div><div class='widget scheduling'>
 <input name="q12:format" value="1" type="hidden"><input name="q12:dim"
   value="4" type="hidden">
+<div class="overlarge">
 <table class="records_list data tMargin">
 <thead><tr><th scope="col">Hour</th><th scope="col">Monday</th></tr></thead><tbody><tr><td><a rel="nofollow" href="http://www.timeanddate.com/worldclock/fixedtime.html?hour=0&amp;min=0&amp;sec=0&amp;p1=1440"> 0 UTC</a></td><td><select name="q12:Monday0"><option value="0" title="I Cannot on Monday at  0 UTC">Cannot</option>
 <option value="1" title="I Can but prefer not on Monday at  0 UTC">Can but prefer not</option>
@@ -353,7 +355,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 <option value="3" title="I Can and prefer on Monday at  2 UTC">Can and prefer</option>
 </select></td>
 </tr>
-</tbody></table>
+</tbody></table></div>
 <p class="rationaleblock"><label for='xq12:rationale'>Rationale</label>: <br />
 <textarea id ='xq12:rationale' name='q12:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq12:comment'>Comments:</label> <br />
@@ -403,6 +405,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 </div><div class='widget ms_importance_satis'>
 <input type='hidden' name='q15:format' value='1' /><input
   type='hidden' name='q15:dim' value='19' />
+<div class="overlarge">
 <table class="records_list data tMargin"><thead><tr><th scope='col'>Rated item</th><th scope='col'>Importance</th><th scope='col'>Satisfaction</th></tr></thead><tbody>
 <tr class='even'><th scope='row'>choice 1</th><td><label
   for='xq15:c1'><select  title='Importance of choice1' name='q15:c1[]'
@@ -486,7 +489,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 											class='even'><th
 											  scope='row'>choice
 											  3</th><td><label
-											    for='xq15:c3'><select  title='Importance of choice3' name='q15:c3[]' id='xq15:c3'><option value='0'>1 + (lowest)</option><option value='1'>2 ++</option><option value='2'>3 +++</option><option value='3'>4 ++++</option><option value='4'>5 +++++</option><option value='5'>6 ++++++</option><option value='6'>7  +++++++ (highest)</option><option value='7'>Not applicable</option><option value='8' selected='selected'>No opinion</option></select></label></td><td><label><select title='Satisfaction on choice3' name='q15:c3[]'><option value='9'>1 + (lowest)</option><option value='10'>2 ++</option><option value='11'>3 +++</option><option value='12'>4 ++++</option><option value='13'>5 +++++</option><option value='14'>6 ++++++</option><option value='15'>7  +++++++ (highest)</option><option value='16'>Didn&#039;t know</option><option value='17'>Not applicable</option><option value='18' selected='selected'>No opinion</option></select></label></td></tr></tbody></table>
+											    for='xq15:c3'><select  title='Importance of choice3' name='q15:c3[]' id='xq15:c3'><option value='0'>1 + (lowest)</option><option value='1'>2 ++</option><option value='2'>3 +++</option><option value='3'>4 ++++</option><option value='4'>5 +++++</option><option value='5'>6 ++++++</option><option value='6'>7  +++++++ (highest)</option><option value='7'>Not applicable</option><option value='8' selected='selected'>No opinion</option></select></label></td><td><label><select title='Satisfaction on choice3' name='q15:c3[]'><option value='9'>1 + (lowest)</option><option value='10'>2 ++</option><option value='11'>3 +++</option><option value='12'>4 ++++</option><option value='13'>5 +++++</option><option value='14'>6 ++++++</option><option value='15'>7  +++++++ (highest)</option><option value='16'>Didn&#039;t know</option><option value='17'>Not applicable</option><option value='18' selected='selected'>No opinion</option></select></label></td></tr></tbody></table></div>
 <p class="rationaleblock"><label for='xq15:rationale'>Rationale</label>: <br />
 <textarea id ='xq15:rationale' name='q15:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq15:comment'>Comments:</label> <br />

--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -166,7 +166,7 @@ Answers received after that time may not be counted.
 <legend><span class="qtitle">4. Select one among many (drop-down list)</span><a class="edit" href="q/q4/" title="Edit text of question &quot;Select one among many (drop-down list)&quot;"><img src="../icons/stock_edit.png" alt="Edit" /></a></legend>
 <div class='content'><p>Select one among many .</p>
 </div><div class='widget select'>
-<p><!-- Please indicate which option matches your choice --><!--:--></p>
+<!-- p>Please indicate which option matches your choice:</p -->
 <input type='hidden' name='q4:format' value='0' /><input type='hidden' name='q4:dim' value='1' /><select name='q4:d1[]'><option value='c1' >choice1</option>
 <option value='c2' >choice 2</option>
 <option value='c3' >choice 3</option>

--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -117,9 +117,9 @@ Answers received after that time may not be counted.
 <div class='content'><p>Simple text question.</p>
 </div><div class='widget text'>
 <p class="rationaleblock"><label for='xq1:rationale'>Rationale</label>: <br />
-<textarea id ='xq1:rationale' name='q1:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq1:rationale' name='q1:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq1:comment'>Comments:</label> <br />
-<textarea id='xq1:comment' name='q1:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq1:comment' name='q1:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -135,9 +135,9 @@ Answers received after that time may not be counted.
 <li><label for='xq2:d1_no_'><input type='radio' name='q2:d1[]' value='no' id='xq2:d1_no_'/>No</label></li>
 </ul>
 <p class="rationaleblock"><label for='xq2:rationale'>Rationale</label>: <br />
-<textarea id ='xq2:rationale' name='q2:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq2:rationale' name='q2:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq2:comment'>Comments:</label> <br />
-<textarea id='xq2:comment' name='q2:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq2:comment' name='q2:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -155,9 +155,9 @@ Answers received after that time may not be counted.
 <li><label for='xq3:d1_abstain_'><input type='radio' name='q3:d1[]' value='abstain' id='xq3:d1_abstain_'/>Blank vote</label></li>
 </ul>
 <p class="rationaleblock"><label for='xq3:rationale'>Rationale</label>: <br />
-<textarea id ='xq3:rationale' name='q3:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq3:rationale' name='q3:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq3:comment'>Comments:</label> <br />
-<textarea id='xq3:comment' name='q3:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq3:comment' name='q3:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -172,9 +172,9 @@ Answers received after that time may not be counted.
 <option value='c3' >choice 3</option>
 </select>
 <p class="rationaleblock"><label for='xq4:rationale'>Rationale</label>: <br />
-<textarea id ='xq4:rationale' name='q4:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq4:rationale' name='q4:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq4:comment'>Comments:</label> <br />
-<textarea id='xq4:comment' name='q4:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq4:comment' name='q4:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -193,9 +193,9 @@ Answers received after that time may not be counted.
   value='c3' id='xq5:d1_c3_'/>choice 3</label></li>
 </ul>
 <p class="rationaleblock"><label for='xq5:rationale'>Rationale</label>: <br />
-<textarea id ='xq5:rationale' name='q5:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq5:rationale' name='q5:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq5:comment'>Comments:</label> <br />
-<textarea id='xq5:comment' name='q5:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq5:comment' name='q5:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -205,9 +205,9 @@ Answers received after that time may not be counted.
 <div class='content'><p>Open comments.</p>
 </div><div class='widget open'>
 <p class="rationaleblock"><label for='xq6:rationale'>Rationale</label>: <br />
-<textarea id ='xq6:rationale' name='q6:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq6:rationale' name='q6:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq6:comment'>Comments:</label> <br />
-<textarea id='xq6:comment' name='q6:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq6:comment' name='q6:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -217,9 +217,9 @@ Answers received after that time may not be counted.
 <div class='content'><p>Text entries.</p>
 </div><div class='widget texts'>
 <input type='hidden' name='q7:format' value='2' /><input type='hidden' name='q7:dim' value='1' /><p class="rationaleblock"><label for='xq7:rationale'>Rationale</label>: <br />
-<textarea id ='xq7:rationale' name='q7:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq7:rationale' name='q7:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq7:comment'>Comments:</label> <br />
-<textarea id='xq7:comment' name='q7:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq7:comment' name='q7:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -238,9 +238,9 @@ name='q8:d1[]' value='c2' />choice 2</label></li>
 name='q8:d1[]' value='c3' />choice 3</label></li>
 </ul>
 <p class="rationaleblock"><label for='xq8:rationale'>Rationale</label>: <br />
-<textarea id ='xq8:rationale' name='q8:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq8:rationale' name='q8:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq8:comment'>Comments:</label> <br />
-<textarea id='xq8:comment' name='q8:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq8:comment' name='q8:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -256,9 +256,9 @@ name='q8:d1[]' value='c3' />choice 3</label></li>
 <li><label for="xq9:c3">choice 3</label>: <select name="q9:c3" id="xq9:c3"><option value="0">1 + (lowest)</option><option value="1">2 ++</option><option value="2">3 +++</option><option value="3">4 ++++</option><option value="4">5 +++++ (highest)</option><option value="5" selected="selected">No opinion</option></select></li>
 </ul>
 <p class="rationaleblock"><label for='xq9:rationale'>Rationale</label>: <br />
-<textarea id ='xq9:rationale' name='q9:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq9:rationale' name='q9:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq9:comment'>Comments:</label> <br />
-<textarea id='xq9:comment' name='q9:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq9:comment' name='q9:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -273,9 +273,9 @@ name='q8:d1[]' value='c3' />choice 3</label></li>
 <li><label for='xq10:c3'>choice 3</label>: <select name='q10:c3' id='xq10:c3'><option value='2'>Yes</option><option value='3'>Yes and prefer</option><option value='1'>Yes, but prefer not</option><option value='0'>No</option></select></li>
 </ul>
 <p class="rationaleblock"><label for='xq10:rationale'>Rationale</label>: <br />
-<textarea id ='xq10:rationale' name='q10:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq10:rationale' name='q10:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq10:comment'>Comments:</label> <br />
-<textarea id='xq10:comment' name='q10:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq10:comment' name='q10:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -321,9 +321,9 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 </tbody>
 </table>
 <p class="rationaleblock"><label for='xq11:rationale'>Rationale</label>: <br />
-<textarea id ='xq11:rationale' name='q11:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq11:rationale' name='q11:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq11:comment'>Comments:</label> <br />
-<textarea id='xq11:comment' name='q11:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq11:comment' name='q11:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -355,9 +355,9 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 </tr>
 </tbody></table>
 <p class="rationaleblock"><label for='xq12:rationale'>Rationale</label>: <br />
-<textarea id ='xq12:rationale' name='q12:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq12:rationale' name='q12:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq12:comment'>Comments:</label> <br />
-<textarea id='xq12:comment' name='q12:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq12:comment' name='q12:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -373,9 +373,9 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 <li><label for="xq13:c4">choice 4</label>: <select name="q13:c4" id="xq13:c4"><option style="color: menutext;" value="0">0</option><option style="color: menutext;" value="1">1</option><option style="color: menutext;" value="2">2</option><option style="color: menutext;" value="3">3</option><option style="color: menutext;" value="4">4</option><option style="color: menutext;" value="5">5</option><option style="color: menutext;" value="6">6</option><option style="color: menutext;" value="7">7</option><option style="color: menutext;" value="8">8</option><option style="color: menutext;" value="9">9</option><option style="color: menutext;" value="10">10</option><option style="color: menutext;" value="11">11</option><option style="color: menutext;" value="12">12</option><option style="color: menutext;" value="13">13</option><option style="color: menutext;" value="14">14</option><option style="color: menutext;" value="15">15</option><option style="color: menutext;" value="16">16</option><option style="color: menutext;" value="17">17</option><option style="color: menutext;" value="18">18</option><option style="color: menutext;" value="19">19</option><option style="color: menutext;" value="20">20</option><option style="color: menutext;" value="21">21</option><option style="color: menutext;" value="22">22</option><option style="color: menutext;" value="23">23</option><option style="color: menutext;" value="24">24</option><option style="color: menutext;" value="25">25</option><option style="color: menutext;" value="26">26</option><option style="color: menutext;" value="27">27</option><option style="color: menutext;" value="28">28</option><option style="color: menutext;" value="29">29</option><option style="color: menutext;" value="30">30</option><option style="color: menutext;" value="31">31</option><option style="color: menutext;" value="32">32</option><option style="color: menutext;" value="33">33</option><option style="color: menutext;" value="34">34</option><option style="color: menutext;" value="35">35</option><option style="color: menutext;" value="36">36</option><option style="color: menutext;" value="37">37</option><option style="color: menutext;" value="38">38</option><option style="color: menutext;" value="39">39</option><option style="color: menutext;" value="40">40</option><option style="color: menutext;" value="41">41</option><option style="color: menutext;" value="42">42</option><option style="color: menutext;" value="43">43</option><option style="color: menutext;" value="44">44</option><option style="color: menutext;" value="45">45</option><option style="color: menutext;" value="46">46</option><option style="color: menutext;" value="47">47</option><option style="color: menutext;" value="48">48</option><option style="color: menutext;" value="49">49</option><option style="color: menutext;" value="50">50</option><option style="color: menutext;" value="51">51</option><option style="color: menutext;" value="52">52</option><option style="color: menutext;" value="53">53</option><option style="color: menutext;" value="54">54</option><option style="color: menutext;" value="55">55</option><option style="color: menutext;" value="56">56</option><option style="color: menutext;" value="57">57</option><option style="color: menutext;" value="58">58</option><option style="color: menutext;" value="59">59</option><option style="color: menutext;" value="60">60</option><option style="color: menutext;" value="61">61</option><option style="color: menutext;" value="62">62</option><option style="color: menutext;" value="63">63</option><option style="color: menutext;" value="64">64</option><option style="color: menutext;" value="65">65</option><option style="color: menutext;" value="66">66</option><option style="color: menutext;" value="67">67</option><option style="color: menutext;" value="68">68</option><option style="color: menutext;" value="69">69</option><option style="color: menutext;" value="70">70</option><option style="color: menutext;" value="71">71</option><option style="color: menutext;" value="72">72</option><option style="color: menutext;" value="73">73</option><option style="color: menutext;" value="74">74</option><option style="color: menutext;" value="75">75</option><option style="color: menutext;" value="76">76</option><option style="color: menutext;" value="77">77</option><option style="color: menutext;" value="78">78</option><option style="color: menutext;" value="79">79</option><option style="color: menutext;" value="80">80</option><option style="color: menutext;" value="81">81</option><option style="color: menutext;" value="82">82</option><option style="color: menutext;" value="83">83</option><option style="color: menutext;" value="84">84</option><option style="color: menutext;" value="85">85</option><option style="color: menutext;" value="86">86</option><option style="color: menutext;" value="87">87</option><option style="color: menutext;" value="88">88</option><option style="color: menutext;" value="89">89</option><option style="color: menutext;" value="90">90</option><option style="color: menutext;" value="91">91</option><option style="color: menutext;" value="92">92</option><option style="color: menutext;" value="93">93</option><option style="color: menutext;" value="94">94</option><option style="color: menutext;" value="95">95</option><option style="color: menutext;" value="96">96</option><option style="color: menutext;" value="97">97</option><option style="color: menutext;" value="98">98</option><option style="color: menutext;" value="99">99</option><option style="color: menutext;" value="100">100</option></select></li>
 <li><span class="label">Total</span>: <input style="color: green;" disabled="disabled"> <span class="label">Remaining</span> <input style="color: green;" disabled="disabled"></li></ul>
 <p class="rationaleblock"><label for='xq13:rationale'>Rationale</label>: <br />
-<textarea id ='xq13:rationale' name='q13:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq13:rationale' name='q13:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq13:comment'>Comments:</label> <br />
-<textarea id='xq13:comment' name='q13:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq13:comment' name='q13:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -390,9 +390,9 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 <li><label for='xq14:c3'>Importance of choice 3</label>: <select name='q14:c3' id='xq14:c3'><option value='0'>1 + (lowest)</option><option value='1'>2 ++</option><option value='2'>3 +++</option><option value='3'>4 ++++</option><option value='4'>5 +++++</option><option value='5'>6 ++++++</option><option value='6'>7  +++++++ (highest)</option><option value='7'>Not applicable</option><option value='8' selected='selected'>No opinion</option></select></li>
 </ul>
 <p class="rationaleblock"><label for='xq14:rationale'>Rationale</label>: <br />
-<textarea id ='xq14:rationale' name='q14:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq14:rationale' name='q14:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq14:comment'>Comments:</label> <br />
-<textarea id='xq14:comment' name='q14:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq14:comment' name='q14:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -488,9 +488,9 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 											  3</th><td><label
 											    for='xq15:c3'><select  title='Importance of choice3' name='q15:c3[]' id='xq15:c3'><option value='0'>1 + (lowest)</option><option value='1'>2 ++</option><option value='2'>3 +++</option><option value='3'>4 ++++</option><option value='4'>5 +++++</option><option value='5'>6 ++++++</option><option value='6'>7  +++++++ (highest)</option><option value='7'>Not applicable</option><option value='8' selected='selected'>No opinion</option></select></label></td><td><label><select title='Satisfaction on choice3' name='q15:c3[]'><option value='9'>1 + (lowest)</option><option value='10'>2 ++</option><option value='11'>3 +++</option><option value='12'>4 ++++</option><option value='13'>5 +++++</option><option value='14'>6 ++++++</option><option value='15'>7  +++++++ (highest)</option><option value='16'>Didn&#039;t know</option><option value='17'>Not applicable</option><option value='18' selected='selected'>No opinion</option></select></label></td></tr></tbody></table>
 <p class="rationaleblock"><label for='xq15:rationale'>Rationale</label>: <br />
-<textarea id ='xq15:rationale' name='q15:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq15:rationale' name='q15:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq15:comment'>Comments:</label> <br />
-<textarea id='xq15:comment' name='q15:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq15:comment' name='q15:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -502,6 +502,7 @@ live with it), where 1  is the most preferred, 2 the next best and so on... You 
 <p><label title='Attending as observer'><input type='radio' name='tp:d1[]' value='obs'  /> Attending as an
 observer only (check at least one of the appropriate requests below  in the 'Observer request' column)</label></p>
 <p>Attending as a  participant in the selected group below:</p>
+<div class="overlarge">
 <table class="records_list data tMargin">
 <thead><tr><th scope='col'>Group meeting</th><th scope='col'>Attending as a participant in this group</th><th scope='col'>Confidentiality</th><th scope='col'>Observer request</th></tr></thead>
 <tbody><tr><th scope='row'></th>
@@ -575,8 +576,8 @@ observer only (check at least one of the appropriate requests below  in the 'Obs
 <td><label><input  title='Requesting observer status for XML Query meeting' type='checkbox' name='tp:d2[]' value='XMLQ' /> (with Chair's agreement)</label></td></tr>
 <tr><th scope='row'>Other (Please specify below)</th>
 <td></td><td></td><td><label><input  title='Attending a meeting not listed here or something not matching one of the above choices' type='checkbox' name='tp:d2[]' value='other' /></label> (explain below)</td></tr>
-</tbody></table><p class="commentblock"><label for='xtp:comment'></label> <br />
-<textarea id='xtp:comment' name='tp:comment' class='comment' rows='3' cols='70'></textarea></p>
+</tbody></table></div><p class="commentblock"><label for='xtp:comment'></label> <br />
+<textarea id='xtp:comment' name='tp:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 </div>
@@ -596,9 +597,9 @@ observer only (check at least one of the appropriate requests below  in the 'Obs
 <select name='q16:d3[]'><option  value='0' >Nobody</option>
 </select>
 <p class="rationaleblock"><label for='xq16:rationale'>Rationale</label>: <br />
-<textarea id ='xq16:rationale' name='q16:rationale' class='rationale' cols='70' rows='6'></textarea></p>
+<textarea id ='xq16:rationale' name='q16:rationale' class='rationale' rows='6'></textarea></p>
 <p class="commentblock"><label for='xq16:comment'>Comments:</label> <br />
-<textarea id='xq16:comment' name='q16:comment' class='comment' rows='3' cols='70'></textarea></p>
+<textarea id='xq16:comment' name='q16:comment' class='comment' rows='3'></textarea></p>
 </div>
 </fieldset>
 


### PR DESCRIPTION
&hellip;as suggested in #11.

I've limited the width of all `textarea`s; now they don't push the width beyond the limits of their containers.

One thing is missing, though: I've wrapped all 4 tables here in `<div class="overlarge">`s, and I've been playing with the CSS properties of both those `div`s and the `table`s they contain, to try and limit their width, and instead have horizontal scrollbars appear when they overflow the parent's width. But I didn't manage to achieve that effect&hellip;

@dontcallmedom or @guibbs, care to take a look and tell me [what properties I'm missing](https://github.com/w3c/wbs-design/blob/tripu/fix-width/css/site-wbs-style.css#L39-L45)? The problem is apparent on small screens.
