### PR TITLE
Make URLs of resources (img, JS) protocol-agnostic

### DIFF
--- a/html/index-site-select2.html
+++ b/html/index-site-select2.html
@@ -40,7 +40,7 @@ title="ATOM feed of my Questionnaires" />
        <li class="search-item">
        <div id="search-form">
        <input tabindex="3" class="text" name="q" value="" title="Search" />
-       <button id="search-submit" name="search-submit" type="submit"><img class="submit" src="http://www.w3.org/2008/site/images/search-button" alt="Search" width="21" height="17" /></button>
+       <button id="search-submit" name="search-submit" type="submit"><img class="submit" src="//www.w3.org/2008/site/images/search-button" alt="Search" width="21" height="17" /></button>
        </div> <!-- /end #w3c_nav -->
        </li>
        </ul>
@@ -51,7 +51,7 @@ title="ATOM feed of my Questionnaires" />
   <div id="w3c_main">
 
   <div id="w3c_logo_shadow" class="w3c_leftCol">
-    <img height="32" alt="" src="http://www.w3.org/2008/site/images/logo-shadow" />
+    <img height="32" alt="" src="//www.w3.org/2008/site/images/logo-shadow" />
   </div> <!-- /end #w3c_logo_shadow -->
 
   <div class="w3c_leftCol">
@@ -1041,7 +1041,7 @@ Maintained by Laurent Carcone, from a development by <a href="https://">Dominiqu
                <h3>W3C Updates</h3>
                <ul class="footer_follow_nav"><li>
                      <a href="http://twitter.com/W3C" title="Follow W3C on Twitter">
-                        <img src="http://www.w3.org/2008/site/images/twitter-bird" alt="Twitter" width="78" height="83" class="social-icon" />
+                        <img src="//www.w3.org/2008/site/images/twitter-bird" alt="Twitter" width="78" height="83" class="social-icon" />
                      </a>
 
                   </li></ul>
@@ -1056,7 +1056,7 @@ Maintained by Laurent Carcone, from a development by <a href="https://">Dominiqu
 
       <div id="w3c_scripts">
       <script type="text/javascript"
-      src="http://www.w3.org/2008/site/js/main" xml:space="preserve">
+      src="//www.w3.org/2008/site/js/main" xml:space="preserve">
 	<![CDATA[
 //
 <!-- -->

--- a/html/qtypes-site.html
+++ b/html/qtypes-site.html
@@ -36,7 +36,7 @@
        <li class="search-item">
        <div id="search-form">
        <input tabindex="3" class="text" name="q" value="" title="Search" />
-       <button id="search-submit" name="search-submit" type="submit"><img class="submit" src="http://www.w3.org/2008/site/images/search-button" alt="Search" width="21" height="17" /></button>
+       <button id="search-submit" name="search-submit" type="submit"><img class="submit" src="//www.w3.org/2008/site/images/search-button" alt="Search" width="21" height="17" /></button>
        </div>
        </li>
        </ul>
@@ -46,7 +46,7 @@
 
 <div id="w3c_main">
   <div id="w3c_logo_shadow" class="w3c_leftCol">
-    <img height="32" alt="" src="http://www.w3.org/2008/site/images/logo-shadow" />
+    <img height="32" alt="" src="//www.w3.org/2008/site/images/logo-shadow" />
   </div>
 
   <div class="w3c_leftCol">
@@ -589,7 +589,7 @@ right persons).<br />
                <h3>W3C Updates</h3>
               <ul class="footer_follow_nav"><li>
                      <a href="http://twitter.com/W3C" title="Follow W3C on Twitter">
-                        <img src="http://www.w3.org/2008/site/images/Twitter_bird_logo_2012.svg" alt="Twitter" height="40" class="social-icon" />
+                        <img src="//www.w3.org/2008/site/images/Twitter_bird_logo_2012.svg" alt="Twitter" height="40" class="social-icon" />
                      </a>
 
                   </li></ul>
@@ -604,7 +604,7 @@ right persons).<br />
 
       <div id="w3c_scripts">
       <script type="text/javascript"
-      src="http://www.w3.org/2008/site/js/main" xml:space="preserve">
+      src="//www.w3.org/2008/site/js/main" xml:space="preserve">
 	<![CDATA[
 //
 <!-- -->


### PR DESCRIPTION
&hellip;to fix issues with mixed-content (eg, the header on [`w3c.github.io/wbs-design/html/qtypes-site.html`](https://w3c.github.io/wbs-design/html/qtypes-site.html) is wrong because the page is served via HTTPS so can't load `http://www.w3.org/2008/site/js/main`).

Trailing spaces were removed automatically.
