### PR TITLE
add placeholders for selects

### DIFF
--- a/html/index-site-select2.html
+++ b/html/index-site-select2.html
@@ -1061,7 +1061,7 @@ Maintained by Laurent Carcone, from a development by <a href="https://">Dominiqu
 //
 ]]></script>
 
-<script type="text/javascript" src="//www.w3.org//scripts/jquery/1.11.3/jquery.min.js"></script>
+<script type="text/javascript" src="//www.w3.org//scripts/jquery/1.11/jquery.min.js"></script>
 <!-- <script type="text/javascript" src="../js/jquery-2.1.0.js"></script> -->
 <script type="text/javascript" src="../js/select2.js"></script>
 <script type="text/javascript">

--- a/html/index-site-select2.html
+++ b/html/index-site-select2.html
@@ -2,7 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="viewport" content="width=device-width, initial-scale=1,
+shrink-to-fit=no" />
 <title>WBS: Web-Based Straw-poll and balloting system - Web-Based Straw-poll and Balloting System</title>
 <!-- <link rel="stylesheet" type="text/css" href="../css/wbs-style.css" title="default" />-->
 <link rel="alternate" type="application/atom+xml" href="https://www.w3.org/2002/09/wbs/myQuestionnaires.atom"
@@ -96,8 +97,8 @@ title="ATOM feed of my Questionnaires" />
 <p>
 <input name="action" value="factory" type="hidden" />
 
-<select name="wgid" id="wgid_create" class="basic-single">
-<option value=' '></option>
+<select name="wgid" id="wgid_create" class="wbs-select">
+<option> </option>
 <option value=' '>Systems</option>
 <option value=' '>AC Meeting attendees group</option>
 <option value=' '>Accessibility in India Community Group</option>
@@ -535,47 +536,46 @@ title="ATOM feed of my Questionnaires" />
 <div class="task2">
 <h3><label for="edit_qaire">Edit a questionnaire ...</label></h3>
 <p>Open questionnaires you're allowed to edit</p>
-<form action="redirect">
+<form action="redirect" method="get">
 <p>
 <input name="action" value="handler" type="hidden" />
-<select name="qaire" id="edit_qaire" class="basic-single">
-<option value=' '></option>
-<option value=''>WBS question types</option>
- <option value=''>Test RFE for WBS</option>
- <option value=''>Availability for WCAG Meetings</option>
- <option value=''>Review Requirements document</option>
- <option value=''>EOWG Weekly Survey - 22 January 2015</option>
- <option value=''>Github proposed responses for January 22nd 2016</option>
- <option value=''>Miscellaneous Survey for January 5 2016</option>
- <option value=''>EOWG Weekly Survey - 15 January 2015</option>
- <option value=''>Availability for Upcoming LVTF Teleconferences</option>
- <option value=''>Call for Review: Patents and Standards Interest G…</option>
- <option value=''>Comments on Extension Requirements Document</option>
- <option value=''>Registration for the Web Component Patent Advisor…</option>
- <option value=''>Availability for Upcoming EOWG Teleconferences</option>
- <option value=''>Call for Review: Permissions &amp; Obligations Expres…</option>
- <option value=''>Registration for the Advisory Committee Meeting, …</option>
- <option value=''>Registration for the F2F meeting of the Web Payme…</option>
- <option value=''>Registration for the F2F meeting of the Web Payme…</option>
- <option value=''>Registration for SVG Working Group Sydney 2016 F2…</option>
- <option value=''>Availability for possible face-to-face EOWG meeti…</option>
- <option value=''>Planning WCAG Face to Face meetings</option>
- <option value=''>W3C Photo Request Form</option>
- <option value=''>IMSC1 Implementation Questionnaire</option>
- <option value=''>Tracking Sexual Harassment Training</option>
- <option value=''>Joining the HTML Accessibility Task Force</option>
- <option value=''>Registration for the XML Security Patent Advisory…</option>
- <option value=''>Grant I: Grant of License for Contributed Test Ca…</option>
- <option value=''>Member Testimonials on the W3C Home Page</option>
- <option value=''>W3C Invited Expert Application</option>
- <option value=''>W3C Office Description</option>
- <option value=''>ERCIM and W3C Europe Internship Request Form</option>
- <option value=''>Offices Activities and Liaisons</option>
- <option value=''>Question Formats</option>
- <option value=''>[Testing] W3C Member Survey</option>
- <option value=''>Please Ignore - Comm Testing</option>
- <option value=''>[Testing] W3C Member Survey</option>
- <option value=''>RDF Data Access Working Group: Disclose or Exclud…</option>
+<select name="qaire" id="edit_qaire" class="wbs-select">
+<option> </option>
+<option value=' '>Test RFE for WBS</option>
+ <option value=' '>Registration for the F2F meeting of the Offices (…</option>
+ <option value=' '>EOWG Weekly Survey - 29 January 2016</option>
+ <option value=' '>Reviewing Low Vision Requirements doc for public …</option>
+ <option value=' '>Web Accessibility Evaluation Tools List Approval</option>
+ <option value=' '>EOWG Weekly Survey - 22 January 2015</option>
+ <option value=' '>Availability for Upcoming LVTF Teleconferences</option>
+ <option value=' '>Registration for the F2F meeting of the Web Annot…</option>
+ <option value=' '>Availability for WCAG Meetings</option>
+ <option value=' '>Miscellaneous Survey for January 5 2016</option>
+ <option value=' '>Call for Review: Patents and Standards Interest G…</option>
+ <option value=' '>Registration for the Web Component Patent Advisor…</option>
+ <option value=' '>Availability for Upcoming EOWG Teleconferences</option>
+ <option value=' '>Call for Review: Permissions &amp; Obligations Expres…</option>
+ <option value=' '>Registration for the Advisory Committee Meeting, …</option>
+ <option value=' '>Registration for the F2F meeting of the Web Payme…</option>
+ <option value=' '>Registration for the F2F meeting of the Web Payme…</option>
+ <option value=' '>Availability for possible face-to-face EOWG meeti…</option>
+ <option value=' '>Planning WCAG Face to Face meetings</option>
+ <option value=' '>W3C Photo Request Form</option>
+ <option value=' '>IMSC1 Implementation Questionnaire</option>
+ <option value=' '>Tracking Sexual Harassment Training</option>
+ <option value=' '>Joining the HTML Accessibility Task Force</option>
+ <option value=' '>Registration for the XML Security Patent Advisory…</option>
+ <option value=' '>Grant I: Grant of License for Contributed Test Ca…</option>
+ <option value=' '>Member Testimonials on the W3C Home Page</option>
+ <option value=' '>W3C Invited Expert Application</option>
+ <option value=' '>W3C Office Description</option>
+ <option value=' '>ERCIM and W3C Europe Internship Request Form</option>
+ <option value=' '>Offices Activities and Liaisons</option>
+ <option value=' '>Question Formats</option>
+ <option value=' '>[Testing] W3C Member Survey</option>
+ <option value=' '>Please Ignore - Comm Testing</option>
+ <option value=' '>[Testing] W3C Member Survey</option>
+ <option value=' '>RDF Data Access Working Group: Disclose or Exclud…</option>
 </select>
 <input value="Go!" type="submit" /></p>
 </form>
@@ -589,10 +589,9 @@ title="ATOM feed of my Questionnaires" />
 <li>
 <form action="redirect">
 <span>
-<label for="wgid_list">On-going questionnaires for the</label>:
-<select name="wgid" id="wgid_list" class="basic-single">
- <option value=' '></option>
-
+<label for="wgid_list">On-going questionnaires for the</label>
+<select name="wgid" id="wgid_list" class="wbs-select">
+<option> </option>
 <option value=' '>Systems</option>
 <option value=' '>AC Meeting attendees group</option>
 <option value=' '>Accessibility in India Community Group</option>
@@ -944,8 +943,8 @@ Gas W…</option>
 <form action="redirect">
 <span><label for="closed_wgid_list">Closed
 questionnaires for the</label>:
-<select name="wgid" id="closed_wgid_list" class="basic-single">
- <option value=' '></option>
+<select name="wgid" id="closed_wgid_list" class="wbs-select">
+ <option>  </option>
  <option value=' '>Test RFE for WBS</option>
  <option value=' '>Registration for the F2F meeting of the Offices (…</option>
  <option value=' '>EOWG Weekly Survey - 29 January 2016</option>
@@ -987,7 +986,6 @@ questionnaires for the</label>:
 </span>
 </form>
 </li>
-
 </ul>
 </div>
 <!--
@@ -1039,13 +1037,13 @@ Maintained by Laurent Carcone, from a development by <a href="https://">Dominiqu
             </div>
             <div class="w3c_footer-nav">
                <h3>W3C Updates</h3>
-               <ul class="footer_follow_nav"><li>
-                     <a href="http://twitter.com/W3C" title="Follow W3C on Twitter">
-                        <img src="//www.w3.org/2008/site/images/twitter-bird" alt="Twitter" width="78" height="83" class="social-icon" />
-                     </a>
-
-                  </li></ul>
-            </div>
+               <ul class="footer_follow_nav">
+               <li><a href="http://twitter.com/W3C" title="Follow W3C
+  on Twitter"><img
+  src="//www.w3.org/2008/site/images/Twitter_bird_logo_2012.svg"
+  alt="Twitter" class="social-icon" height="40" /></a></li>
+                </ul>
+           </div>
             <p class="copyright">Copyright © 2016 W3C <sup>®</sup> (<a href="http://www.csail.mit.edu/">
                   <acronym title="Massachusetts Institute of Technology">MIT</acronym>
                </a>, <a href="http://www.ercim.org/">
@@ -1063,11 +1061,16 @@ Maintained by Laurent Carcone, from a development by <a href="https://">Dominiqu
 //
 ]]></script>
 
-<script type="text/javascript" src="../js/jquery-2.1.0.js"></script>
+<script type="text/javascript" src="//www.w3.org//scripts/jquery/1.11.3/jquery.min.js"></script>
+<!-- <script type="text/javascript" src="../js/jquery-2.1.0.js"></script> -->
 <script type="text/javascript" src="../js/select2.js"></script>
 <script type="text/javascript">
 $(document).ready(function() {
-  $(".basic-single").select2();
+ $(".wbs-select").select2({
+    placeholder: "Select a Group",
+    allowClear: true
+});
+
 });
 </script>
 


### PR DESCRIPTION
Hi Tripu,
I looked at your comments in https://github.com/w3c/wbs-design/pull/9 about the implementation of select2 plugin. I made some modifications in index-site-select2.html:
. it is now using jquery 1.11.3 from w3c (we can copy this version if it is faster)
. I replaced the old twitter logo
. I have added a placeholder for the selects
About the focus problem, it is indeed by design. I guess we should ask for WAI advice if it is better like that or if we have to modify this behaviour if we choose to use select2.

Thanks,
Laurent
